### PR TITLE
[FailureHandling] Added RetryMonitor, which lets us retry a plan including a corresponding Monitor

### DIFF
--- a/examples/retry_monitor.ipynb
+++ b/examples/retry_monitor.ipynb
@@ -1,0 +1,116 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pycram.designators.action_designator import *\n",
+    "from pycram.designators.location_designator import *\n",
+    "from pycram.designators.object_designator import *\n",
+    "from pycram.failure_handling import RetryMonitor\n",
+    "from pycram.bullet_world import BulletWorld, Object\n",
+    "from pycram.language import Monitor, Code\n",
+    "from pycram.pose import Pose\n",
+    "from pycram.process_module import simulated_robot\n",
+    "from pycram.ros.viz_marker_publisher import VizMarkerPublisher"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world = BulletWorld(\"DIRECT\")\n",
+    "viz = VizMarkerPublisher()\n",
+    "robot = Object(\"pr2\", \"robot\", \"pr2.urdf\", pose=Pose([1, 2, 0]))\n",
+    "apartment = Object(\"apartment\", \"environment\", \"apartment.urdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "robot_desig = BelieveObject(names=[\"pr2\"])\n",
+    "apartment_desig = BelieveObject(names=[\"apartment\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "height = 0.3\n",
+    "sleep_time = 2\n",
+    "\n",
+    "def monitor():\n",
+    "    global height\n",
+    "    time.sleep(1)\n",
+    "    if height == 0.3:\n",
+    "        height = 0.1\n",
+    "    else:\n",
+    "        height = 0.3\n",
+    "    print(\"Triggered\")\n",
+    "    return True\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "with simulated_robot:\n",
+    "    sleep = Code(lambda: time.sleep(sleep_time))\n",
+    "    code = Code(lambda: print(height))\n",
+    "\n",
+    "    # Call MoveTorso like this to be able to adjust the parameters manually between repeat steps, for example\n",
+    "    # the height for MoveTorsoAction, or the object one wants to grasp for pickup\n",
+    "    move_torso = Code(lambda: MoveTorsoAction([height]).resolve().perform())\n",
+    "\n",
+    "    # plan = print out current height, then move torso, then sleep for sleep_time. Do that twice.\n",
+    "    # If monitor condition is triggered (aka returns True), current action is interrupted, and plan is repeated\n",
+    "    plan = (code + move_torso + sleep) * 2 >> Monitor(monitor)\n",
+    "\n",
+    "    RetryMonitor(plan, max_tries=5).perform()"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [],
+   "metadata": {
+    "collapsed": false
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Adds "RetryMonitor", which retries a plan up until max_tries times, while refreshing the monitoring of that plan. An example of that can be found in "examples/retry_monitor.ipynb", which showcases how RetryMonitor is to be used, and also how to manually, update variables at runtime while using RetryMonitor.

The .perform() method of the Monitor class was adjusted slightly to allow for smooth and consistent refreshing of the monitor, as the old "check_condition" implementation seemed to sometimes cause the condition not to be checked properly after it was refreshed, due to the sleep loop.

Furthermore, it is now Raising a PlanFailure error if the condition is met, which is caught by the RetryMonitor.

Lastly, the class FailureHandling now inherits from Language, to allow passing instances of FailureHandling to be monitored as well, and designator_description is now expected to be "Union[DesignatorDescription, Monitor]".