### PR TITLE
[InterruptClient] moved imports from init method to outside the class

### DIFF
--- a/src/pycram/external_interfaces/interrupt_actionclient.py
+++ b/src/pycram/external_interfaces/interrupt_actionclient.py
@@ -2,14 +2,15 @@ import rospy
 from time import time
 from pycram.fluent import Fluent
 
-
+try:
+    from speech_processing.msg import message_to_robot, message_from_robot, message_objects_in_use, dict_object
+except ModuleNotFoundError as e:
+    rospy.logwarn("Failed to import speech_processing messages, frontiers can not be used")
+            
 class InterruptClient:
 
     def __init__(self):
-        try:
-            from speech_processing.msg import message_to_robot, message_from_robot, message_objects_in_use, dict_object
-        except ModuleNotFoundError as e:
-            rospy.logwarn("Failed to import speech_processing messages, frontiers can not be used")
+        
         self.minor_interrupt = Fluent()
 
         self.nlp_frequency = 10.0


### PR DESCRIPTION
Testing revealed that the class interal imports turned out to be problematic, so I moved them outside of the class. Try-Except is still intact