### PR TITLE
[ProcessModules] fixed formula for tilting the robot head

### DIFF
--- a/src/pycram/process_modules/armar6_process_modules.py
+++ b/src/pycram/process_modules/armar6_process_modules.py
@@ -109,14 +109,17 @@ class ARMAR6MoveHead(ProcessModule):
         pose_in_tilt = local_transformer.transform_pose(target, robot.get_link_tf_frame("upper_neck"))
 
         new_pan = np.arctan2(pose_in_pan.position.y, pose_in_pan.position.x)
-        new_tilt = np.arctan2(pose_in_tilt.position.z, np.sqrt(pose_in_tilt.position.x ** 2 + pose_in_tilt.position.y ** 2))
+
+        # For some reason the values for position.y and position.z are swapped, so for now the formula is adjusted accordingly.
+        # Not guaranteed to work in all cases, depending on the reason why the values are swapped for this robot (maybe wrong urdf or something?)
+        new_tilt = - np.arctan2(pose_in_tilt.position.y, np.sqrt(pose_in_tilt.position.x ** 2 + pose_in_tilt.position.z ** 2))
+
 
         current_pan = robot.get_joint_state("neck_1_yaw")
         current_tilt = robot.get_joint_state("neck_2_pitch")
 
         robot.set_joint_state("neck_1_yaw", new_pan + current_pan)
-        # robot.set_joint_state("neck_2_pitch", new_tilt + current_tilt)
-        robot.set_joint_state("neck_2_pitch", new_tilt)
+        robot.set_joint_state("neck_2_pitch", new_tilt + current_tilt)
 
 
 

--- a/src/pycram/process_modules/hsrb_process_modules.py
+++ b/src/pycram/process_modules/hsrb_process_modules.py
@@ -325,6 +325,8 @@ class HSRBMoveHeadReal(ProcessModule):
 
         new_pan = np.arctan2(pose_in_pan.position.y, pose_in_pan.position.x)
         new_tilt = np.arctan2(pose_in_tilt.position.z, pose_in_tilt.position.x + pose_in_tilt.position.y)
+        # comment out the correct formula to test it on the hsrb before fully swapping it out
+        # new_tilt = np.arctan2(pose_in_tilt.position.z, np.sqrt(pose_in_tilt.position.x ** 2 + pose_in_tilt.position.y ** 2)) * -1
 
         current_pan = robot.get_joint_state("head_pan_joint")
         current_tilt = robot.get_joint_state("head_tilt_joint")

--- a/src/pycram/process_modules/pr2_process_modules.py
+++ b/src/pycram/process_modules/pr2_process_modules.py
@@ -118,7 +118,7 @@ class Pr2MoveHead(ProcessModule):
         pose_in_tilt = local_transformer.transform_pose(target, robot.get_link_tf_frame("head_tilt_link"))
 
         new_pan = np.arctan2(pose_in_pan.position.y, pose_in_pan.position.x)
-        new_tilt = np.arctan2(pose_in_tilt.position.z, pose_in_tilt.position.x ** 2 + pose_in_tilt.position.y ** 2) * -1
+        new_tilt = np.arctan2(pose_in_tilt.position.z, np.sqrt(pose_in_tilt.position.x ** 2 + pose_in_tilt.position.y ** 2)) * -1
 
         current_pan = robot.get_joint_state("head_pan_joint")
         current_tilt = robot.get_joint_state("head_tilt_joint")


### PR DESCRIPTION
The corrected formula "new_tilt = np.arctan2(pose_in_tilt.position.z, np.sqrt(pose_in_tilt.position.x ** 2 + pose_in_tilt.position.y ** 2)) * -1" now correctly calculates the distance between the head link and the target pose.

For some reason, the values for position.y and position.z are swapped for the ARMAR6 robot, so the formula is adjusted accordingly until the underlying error is found.

The HSRB has not been tested with the corrected formula, so I commented it out for now. The comment can be found in file "src/pycram/process_modules/hsrb_process_modules.py", in line 329. Be aware that depending on the axis rotation of the link, it might be necessary to remove the " * -1 " from the end of the formula.
