### PR TITLE
[Frontiers] Multiple Commands, duplicate object, setting-breakfast

### DIFF
--- a/demos/frontiers/interrupt_demo.py
+++ b/demos/frontiers/interrupt_demo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# !/usr/bin/env python3
 import time
 
 from pycram.designators.action_designator import *
@@ -16,6 +15,11 @@ from pycram.bullet_world import BulletWorld, Object
 from pycram.process_module import simulated_robot, with_simulated_robot
 from pycram.ros.viz_marker_publisher import VizMarkerPublisher
 
+try:
+    from speech_processing.msg import dict_object
+except ModuleNotFoundError as e:
+    rospy.logwarn("Failed to import speech_processing messages, frontiers can not be used")
+
 world = BulletWorld("DIRECT")
 viz = VizMarkerPublisher()
 robot = Object("pr2", "robot", "pr2.urdf", pose=Pose([1, 2, 0]))
@@ -24,8 +28,10 @@ apartment = Object("apartment", "environment", "apartment.urdf")
 milk1 = Object("milk1", "milk", "milk.stl", pose=Pose([2.5, 2, 1.02]), color=[0, 0, 1, 1])
 milk2 = Object("milk2", "milk", "milk.stl", pose=Pose([2.5, 1.7, 1.02]), color=[1, 0, 0, 1], size="big")
 bowl = Object("bowl", "bowl", "bowl.stl", pose=Pose([2.5, 2.2, 1.02]), color=[1, 1, 1, 1])
-
+spoon = Object("spoon", "spoon", "spoon.stl", pose=Pose([2.4, 2.2, 0.85]), color=[0, 0, 1, 1])
 cereal = Object("cereal", "cereal", "breakfast_cereal.stl", pose=Pose([2.5, 2.4, 1.05]), color=[0, 1, 0, 1])
+
+apartment.attach(spoon, 'cabinet10_drawer_top')
 
 pick_pose = Pose([2.7, 2.15, 1])
 
@@ -43,6 +49,7 @@ place_pose = None
 nav_pose = None
 original_pose = None
 obj_desig = None
+current_cmd = None
 
 
 def color_map(color):
@@ -85,6 +92,16 @@ def get_place_pose(object_type):
     return pose
 
 
+def get_recovery_pose(object_type):
+    poses = {
+        'bowl': Pose([1.7, 1.9, 0]),
+        'cereal': Pose([1.7, 2, 0]),
+        'milk': Pose([1.7, 1.9, 0]),
+    }
+    pose = poses.get(object_type)
+    return pose
+
+
 def get_nav_pose(object_type):
     global age
     poses = {
@@ -100,19 +117,56 @@ def get_nav_pose(object_type):
     return pose
 
 
-def monitor_func():
-    global obj_type, obj_color, obj_name, obj_location, obj_size, age
-    if fluent.minor_interrupt.get_value():
-        obj = fluent.objects_in_use.get(obj_type, None)
-        if obj:
-            new_attributes = (obj.type.lower(), obj.color, obj.name.lower(), obj.location, obj.size.lower())
+def update_current_command():
+    global current_cmd, obj_type, obj_color, obj_name, obj_location, obj_size
+    current_cmd = fluent.next_command()
+
+    if current_cmd:
+        minor_cmd = current_cmd.get("minor", {}).get("command")
+
+        if minor_cmd == "setting-breakfast":
+            objects_to_add = [
+                dict_object(type="bowl", color="", name="", location="", size=""),
+                dict_object(type="milk", color="", name="", location="", size=""),
+                dict_object(type="cereal", color="", name="", location="", size="")
+            ]
+            fluent.modify_objects_in_use(objects_to_add, [])
+
+        # elif minor_cmd == "object":
+        else:
             old_attributes = (obj_type.lower(), obj_color, obj_name.lower(), obj_location, obj_size.lower())
 
-            if new_attributes != old_attributes:
+            del_cmd = current_cmd.get("minor", {}).get("del_object")
+            if del_cmd:
+                del_obj = del_cmd[0]
+                del_attributes = (
+                    del_obj.type.lower(), del_obj.color, del_obj.name.lower(), del_obj.location, del_obj.size.lower())
+            else:
+                del_attributes = None
+
+            add_cmd = current_cmd.get("minor", {}).get("add_object")
+            if add_cmd:
+                add_obj = add_cmd[0]
+                new_attributes = (
+                    add_obj.type.lower(), add_obj.color, add_obj.name.lower(), add_obj.location, add_obj.size.lower())
+            else:
+                new_attributes = None
+
+            if old_attributes == del_attributes and new_attributes:
                 obj_type, obj_color, obj_name, obj_location, obj_size = new_attributes
-                fluent.minor_interrupt.set_value(False)
-                return True
-            return False
+
+
+def monitor_func():
+    global obj_type, obj_color, obj_name, obj_location, obj_size, age, current_cmd
+    if fluent.minor_interrupt.get_value():
+        old_attributes = (obj_type.lower(), obj_color, obj_name.lower(), obj_location, obj_size.lower())
+        update_current_command()
+
+        new_attributes = (obj_type.lower(), obj_color, obj_name.lower(), obj_location, obj_size.lower())
+        if new_attributes != old_attributes:
+            fluent.minor_interrupt.set_value(False)
+            return True
+        return False
     elif fluent.major_interrupt.get_value():
         return MajorInterrupt
     return False
@@ -122,12 +176,25 @@ def monitor_func():
 def move_and_detect(obj_type, obj_size, obj_color):
     global original_pose
     obj_color = color_map(obj_color)
-    NavigateAction(target_locations=[Pose([1.7, 1.9, 0])]).resolve().perform()
 
-    LookAtAction(targets=[pick_pose]).resolve().perform()
-    # object_desig = DetectAction(BelieveObject(types=[obj_type] if obj_type else None,
-    #                                          sizes=[obj_size] if obj_size else None,
-    #                                          colors=[obj_color] if obj_color else None)).resolve().perform()
+    if obj_type == "spoon":
+        handle_desig = ObjectPart(names=["handle_cab10_t"], part_of=apartment_desig.resolve())
+        drawer_open_loc = AccessingLocation(handle_desig=handle_desig.resolve(),
+                                            robot_desig=robot_desig.resolve()).resolve()
+        NavigateAction([drawer_open_loc.pose]).resolve().perform()
+        OpenAction(object_designator_description=handle_desig, arms=[drawer_open_loc.arms[0]]).resolve().perform()
+        spoon.detach(apartment)
+
+        # Detect and pickup the spoon
+        LookAtAction([apartment.get_link_pose("handle_cab10_t")]).resolve().perform()
+
+    else:
+        NavigateAction(target_locations=[Pose([1.7, 1.9, 0])]).resolve().perform()
+
+        LookAtAction(targets=[pick_pose]).resolve().perform()
+        # object_desig = DetectAction(BelieveObject(types=[obj_type] if obj_type else None,
+        #                                          sizes=[obj_size] if obj_size else None,
+        #                                          colors=[obj_color] if obj_color else None)).resolve().perform()
     status, object_dict = DetectAction(technique='all').resolve().perform()
     filtered_dict = {
         key: obj
@@ -145,7 +212,9 @@ def move_and_detect(obj_type, obj_size, obj_color):
 def announce_pick(name: str, type: str, color: str, location: str, size: str):
     print(f"I will now pick up the {size.lower()} {color.lower()} {type.lower()} at location {location.lower()} ")
     print(f"I am now interruptable for 5 seconds")
+    fluent.activate_subs()
     time.sleep(5)
+    fluent.deactivate_subs()
     print(f"I am not interruptable any more")
 
 
@@ -153,7 +222,9 @@ def announce_bring(name: str, type: str, color: str, location: str, size: str):
     print(f"I will now bring the {size.lower()} {color.lower()} {type.lower()} to you")
     from_robot_publish("transporting", True, False, True, "countertop", "table")
     print(f"I am now interruptable for 10 seconds")
+    fluent.activate_subs()
     time.sleep(10)
+    fluent.deactivate_subs()
     print(f"I am not interruptable any more")
 
 
@@ -189,159 +260,87 @@ with simulated_robot:
 
     MoveTorsoAction([0.25]).resolve().perform()
     from_robot_publish("initial", True, False, False, "countertop", "")
-    print("Waiting for a human command")
-    fluent.minor_interrupt.pulsed().wait_for()
-    obj = fluent.objects_in_use.get("bowl", None)
-    if obj:
-        obj_type = obj.type
-        obj_color = obj.color
-        obj_name = obj.name
-        obj_location = obj.location
-        obj_size = obj.size
+    handled_objects = []
+    unhandled_objects = []
 
-        fluent.minor_interrupt.set_value(False)
-        age = fluent.age
-        print("Received human command")
+    while True:
+        if not unhandled_objects:
+            print("Waiting for next human command")
+            fluent.activate_subs()
+            fluent.minor_interrupt.pulsed().wait_for()
+            fluent.deactivate_subs()
+            update_current_command()
+            print(f"Received command: {current_cmd.get('minor', {}).get('command')}")
 
-        ###### Announce object and wait ######
-        announce = Code(lambda: announce_pick(obj_name, obj_type, obj_color, obj_location, obj_size))
+        unhandled_objects = list(fluent.objects_in_use.keys())
 
-        ###### Move and detect object ######
-        obj_desig = Code(lambda: move_and_detect(obj_type, obj_size, obj_color))
+        for obj in unhandled_objects:
+            if obj in handled_objects:
+                print(f"Object {obj} was already handled, continuing")
 
-        ###### construct and monitor subplan ######
-        plan = announce + obj_desig >> Monitor(monitor_func)
+        # Filter out already handled objects
+        unhandled_objects = [obj for obj in unhandled_objects if obj not in handled_objects]
 
-        ###### Execute plan ######
-        _, [_, obj_desig] = RetryMonitor(plan, max_tries=5).perform()
+        unhandled_object = unhandled_objects[0] if unhandled_objects else None
 
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
+        if unhandled_object:
+            obj = fluent.objects_in_use.get(unhandled_object, None)
+        else:
+            obj = None
 
-        ###### Pickup Object ######
-        from_robot_publish("picking_up", True, True, False, "countertop", "")
-        PickUpAction.Action(obj_desig, "left", "front").perform()
+        if obj:
+            obj_type = obj.type
+            obj_color = obj.color
+            obj_name = obj.name
+            obj_location = obj.location
+            obj_size = obj.size
 
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
+            fluent.minor_interrupt.set_value(False)
+            age = fluent.age
 
-        ###### Announce Navigation action and wait ######
-        announce = Code(lambda: announce_bring(obj_name, obj_type, obj_color, obj_location, obj_size))
+            ###### Announce object and wait ######
+            announce = Code(lambda: announce_pick(obj_name, obj_type, obj_color, obj_location, obj_size))
 
-        ###### Construct subplan ######
-        plan = NavigateAction([get_nav_pose(obj_type)]) + announce >> Monitor(monitor_func)
+            ###### Move and detect object ######
+            obj_desig = Code(lambda: move_and_detect(obj_type, obj_size, obj_color))
 
-        ###### Construct recovery behaviour (Navigate to island => place object => detect new object => pick up new object ######
-        recover = Code(lambda: announce_recovery()) + NavigateAction([Pose([1.7, 1.9, 0])]) + Code(
-            lambda: place_and_pick_new_obj(obj_desig, original_pose, obj_type, obj_size, obj_color))
+            ###### construct and monitor subplan ######
+            plan = announce + obj_desig >> Monitor(monitor_func)
 
-        ###### Execute plan ######
-        RetryMonitor(plan, max_tries=5, recovery=recover).perform()
+            ###### Execute plan ######
+            _, [_, obj_desig] = RetryMonitor(plan, max_tries=5).perform()
 
-        ###### Hand the object according to Scenario 5 ######
-        from_robot_publish("placing", True, True, False, "table", "")
-        PlaceAction(obj_desig, ["left"], ["front"], [get_place_pose(obj_type)]).resolve().perform()
-        ParkArmsAction([Arms.BOTH]).resolve().perform()
+            ###### Park robot ######
+            ParkArmsAction.Action(Arms.BOTH).perform()
 
-    obj = fluent.objects_in_use.get("milk", None)
-    if obj:
-        obj_type = obj.type
-        obj_color = obj.color
-        obj_name = obj.name
-        obj_location = obj.location
-        obj_size = obj.size
+            ###### Pickup Object ######
+            from_robot_publish("picking_up", True, True, False, "countertop", "")
+            PickUpAction.Action(obj_desig, "left", "front").perform()
 
-        fluent.minor_interrupt.set_value(False)
-        age = fluent.age
+            ###### Park robot ######
+            ParkArmsAction.Action(Arms.BOTH).perform()
 
-        ###### Announce object and wait ######
-        announce = Code(lambda: announce_pick(obj_name, obj_type, obj_color, obj_location, obj_size))
+            ###### Announce Navigation action and wait ######
+            announce = Code(lambda: announce_bring(obj_name, obj_type, obj_color, obj_location, obj_size))
 
-        ###### Move and detect object ######
-        obj_desig = Code(lambda: move_and_detect(obj_type, obj_size, obj_color))
+            ###### Construct subplan ######
+            plan = Code(lambda: NavigateAction([get_nav_pose(obj_type)]).resolve().perform()) + announce >> Monitor(
+                monitor_func)
 
-        ###### construct and monitor subplan ######
-        plan = announce + obj_desig >> Monitor(monitor_func)
+            ###### Construct recovery behaviour (Navigate to island => place object => detect new object => pick up new object ######
+            recover = Code(lambda: announce_recovery()) + NavigateAction([get_recovery_pose(obj_type)]) + Code(
+                lambda: place_and_pick_new_obj(obj_desig, original_pose, obj_type, obj_size, obj_color))
 
-        ###### Execute plan ######
-        _, [_, obj_desig] = RetryMonitor(plan, max_tries=5).perform()
+            ###### Execute plan ######
+            RetryMonitor(plan, max_tries=5, recovery=recover).perform()
 
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
+            ###### Hand the object according to Scenario 5 ######
+            from_robot_publish("placing", True, True, False, "table", "")
+            PlaceAction(obj_desig, ["left"], ["front"], [get_place_pose(obj_type)]).resolve().perform()
+            ParkArmsAction([Arms.BOTH]).resolve().perform()
 
-        ###### Pickup Object ######
-        from_robot_publish("picking_up", True, True, False, "countertop", "")
-        PickUpAction.Action(obj_desig, "left", "front").perform()
+            if obj_type in unhandled_objects:
+                unhandled_objects.remove(obj_type)
 
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
-
-
-        ###### Announce Navigation action and wait ######
-        announce = Code(lambda: announce_bring(obj_name, obj_type, obj_color, obj_location, obj_size))
-
-        ###### Construct subplan ######
-        plan = NavigateAction([get_nav_pose(obj_type)]) + announce >> Monitor(monitor_func)
-
-        ###### Construct recovery behaviour (Navigate to island => place object => detect new object => pick up new object ######
-        recover = Code(lambda: announce_recovery()) + NavigateAction([Pose([1.7, 2, 0])]) + Code(
-            lambda: place_and_pick_new_obj(obj_desig, original_pose, obj_type, obj_size, obj_color))
-
-        ###### Execute plan ######
-        RetryMonitor(plan, max_tries=5, recovery=recover).perform()
-
-        ###### Hand the object according to Scenario 5 ######
-        from_robot_publish("placing", True, True, False, "table", "")
-        PlaceAction(obj_desig, ["left"], ["front"], [get_place_pose(obj_type)]).resolve().perform()
-        ParkArmsAction([Arms.BOTH]).resolve().perform()
-
-    obj = fluent.objects_in_use.get("cereal", None)
-    if obj:
-        obj_type = obj.type
-        obj_color = obj.color
-        obj_name = obj.name
-        obj_location = obj.location
-        obj_size = obj.size
-
-        fluent.minor_interrupt.set_value(False)
-        age = fluent.age
-
-        ###### Announce object and wait ######
-        announce = Code(lambda: announce_pick(obj_name, obj_type, obj_color, obj_location, obj_size))
-
-        ###### Move and detect object ######
-        obj_desig = Code(lambda: move_and_detect(obj_type, obj_size, obj_color))
-
-        ###### construct and monitor subplan ######
-        plan = announce + obj_desig >> Monitor(monitor_func)
-
-        ###### Execute plan ######
-        _, [_, obj_desig] = RetryMonitor(plan, max_tries=5).perform()
-
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
-
-        ###### Pickup Object ######
-        from_robot_publish("picking_up", True, True, False, "countertop", "")
-        PickUpAction.Action(obj_desig, "left", "front").perform()
-
-        ###### Park robot ######
-        ParkArmsAction.Action(Arms.BOTH).perform()
-
-        ###### Announce Navigation action and wait ######
-        announce = Code(lambda: announce_bring(obj_name, obj_type, obj_color, obj_location, obj_size))
-
-        ###### Construct subplan ######
-        plan = NavigateAction([get_nav_pose(obj_type)]) + announce >> Monitor(monitor_func)
-
-        ###### Construct recovery behaviour (Navigate to island => place object => detect new object => pick up new object ######
-        recover = Code(lambda: announce_recovery()) + NavigateAction([Pose([1.7, 2, 0])]) + Code(
-            lambda: place_and_pick_new_obj(obj_desig, original_pose, obj_type, obj_size, obj_color))
-
-        ###### Execute plan ######
-        RetryMonitor(plan, max_tries=5, recovery=recover).perform()
-
-        ###### Hand the object according to Scenario 5 ######
-        from_robot_publish("placing", True, True, False, "table", "")
-        PlaceAction(obj_desig, ["left"], ["front"], [get_place_pose(obj_type)]).resolve().perform()
-        ParkArmsAction([Arms.BOTH]).resolve().perform()
+            if obj_type not in handled_objects:
+                handled_objects.append(obj_type)


### PR DESCRIPTION
Code was cleaned up a bit and plan now runs in a loop to properly support multiple commands chained together. 

If user tries to use the same object type twice, it prints an error that the object type was already handled.

The robot now properly sets the table when called using the "setting-breakfast" command (as specified on the trello architecture).

Other than that, a lot of cleanups and changes to properly utilize the commands and handle interrupts accordingly, and now dynamically connects the subscribers only when the user is allowed to interrupt.