### PR TITLE
[Frontiers] moved cup to cupboard. 

### DIFF
--- a/src/pycram/designators/action_designator.py
+++ b/src/pycram/designators/action_designator.py
@@ -325,7 +325,7 @@ class PickUpAction(ActionDesignatorDescription):
                 oTm.pose.position.z += 0.02
             elif self.grasp == "front":
                 if self.object_designator.type == "cup":
-                    oTm.pose.position.z += 0.1
+                    oTm.pose.position.z += 0.05
 
             # Determine the grasp orientation and transform the pose to the base link frame
             grasp_rotation = robot_description.grasps.get_orientation_for_grasp(self.grasp)
@@ -542,7 +542,8 @@ class PlaceAction(ActionDesignatorDescription):
 
             # rospy.logwarn("Lifting now")
             liftingTm = push_baseTm
-            liftingTm.pose.position.z += 0.03
+            if self.grasp == "top":
+                liftingTm.pose.position.z += 0.03
             BulletWorld.current_bullet_world.add_vis_axis(liftingTm)
 
             MoveTCPMotion(liftingTm, self.arm).resolve().perform()

--- a/src/pycram/designators/location_designator.py
+++ b/src/pycram/designators/location_designator.py
@@ -266,6 +266,9 @@ class AccessingLocation(LocationDesignatorDescription):
         # Find a Joint of type prismatic which is above the handle in the URDF tree
         container_joint = self.handle.bullet_world_object.find_joint_above(self.handle.name, JointType.PRISMATIC)
 
+        if not container_joint:
+            container_joint = self.handle.bullet_world_object.find_joint_above(self.handle.name, JointType.REVOLUTE)
+
         init_pose = link_pose_for_joint_config(self.handle.bullet_world_object, {
             container_joint: self.handle.bullet_world_object.get_joint_limits(container_joint)[0]},
                                                self.handle.name)
@@ -280,10 +283,12 @@ class AccessingLocation(LocationDesignatorDescription):
             container_joint: self.handle.bullet_world_object.get_joint_limits(container_joint)[1] / 1.5},
                                                self.handle.name)
 
+        # handle_cab1_top_door currently cant be used to open cab1. it could be that currently it tries to grasp and
+        # fully open the door without moving the base, because when using cabinet1_door_top_left, it causes the robot
+        # to grasp the wrong side of the door, but then successfully opens it __without__ moving the base
         with Use_shadow_world():
             for maybe_pose in pose_generator(final_map, number_of_samples=600,
                                              orientation_generator=lambda p, o: generate_orientation(p, half_pose)):
-
                 hand_links = []
                 for name, chain in robot_description.chains.items():
                     if isinstance(chain, ManipulatorDescription):

--- a/src/pycram/process_modules/pr2_process_modules.py
+++ b/src/pycram/process_modules/pr2_process_modules.py
@@ -242,6 +242,9 @@ class Pr2Open(ProcessModule):
 
         container_joint = part_of_object.find_joint_above(desig.object_part.name, JointType.PRISMATIC)
 
+        if not container_joint:
+            container_joint = part_of_object.find_joint_above(desig.object_part.name, JointType.REVOLUTE)
+
         goal_pose = btr.link_pose_for_joint_config(part_of_object, {
             container_joint: part_of_object.get_joint_limits(container_joint)[1] - 0.05}, desig.object_part.name)
 
@@ -261,6 +264,9 @@ class Pr2Close(ProcessModule):
         part_of_object = desig.object_part.bullet_world_object
 
         container_joint = part_of_object.find_joint_above(desig.object_part.name, JointType.PRISMATIC)
+
+        if not container_joint:
+            container_joint = part_of_object.find_joint_above(desig.object_part.name, JointType.REVOLUTE)
 
         goal_pose = btr.link_pose_for_joint_config(part_of_object, {
             container_joint: part_of_object.get_joint_limits(container_joint)[0]}, desig.object_part.name)


### PR DESCRIPTION
Moved Cup to Cupboard and now Opening and Closing supports Revolute Joints. For this
Location_designator.py and the PR2 process module had to be slightly adjusted, but this
should have no impact on any other usecases.

Also Fixed an issue where the PR2 would not close the drawer after picking up the spoon 
inside the recovery behaviour.