### PR TITLE
[binder] Reduced webapps.json to reduce memory usage

### DIFF
--- a/binder/webapps.json
+++ b/binder/webapps.json
@@ -6,32 +6,13 @@
     "url": "proxy/8001/rvizweb/webapps/rvizweb/build/www/index.html",
     "start": true,
     "mode": "split-right"
-  },
-  {
-    "name": "XPRA",
-    "title": "Xpra Desktop",
-    "icon": "proxy/8001/rvizweb/webapps/xpra-logo.svg",
-    "url": "xprahtml5/index.html",
-    "start": true,
-    "mode": "split-left"
-  },
-  
+  },  
   {
     "name": "rosgraph",
     "title": "Ros Graph",
     "icon": "proxy/8001/rvizweb/webapps/o.svg",
-    "url": "proxy/8001/rvizweb/webapps/ros-node-graph/build/index.html"
-  },
-  {
-    "name": "rosboard",
-    "title": "ROSBoard",
-    "icon": "proxy/8001/rvizweb/webapps/s.svg",
-    "url": "proxy/18888/index.html"
-  },
-  {
-    "name": "webviz",
-    "title": "Webviz",
-    "icon": "proxy/8001/rvizweb/webapps/webviz/icon.svg",
-    "url": "proxy/8001/rvizweb/webapps/webviz/index.html"
+    "url": "proxy/8001/rvizweb/webapps/ros-node-graph/build/index.html",
+    "start": true,
+    "mode": "split-left"
   }
 ]


### PR DESCRIPTION
To reduce memory usage in binder instances, this change removes xpra and other apps from the webapps.json.
To keep the same structure with two tabs open in binder, rosgraph is now started on the left instead of xpra.  