### PR TITLE
Recolor Kitchen and Apartment URDFs for Consistent Appearance

### DIFF
--- a/resources/IAI_kitchen.urdf
+++ b/resources/IAI_kitchen.urdf
@@ -4,6 +4,27 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="iai_oven_area" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="cabinet_handles">
+    <color rgba="0.6 0.6 0.6 1"/>
+  </material>
+  <material name="cabinet_surface">
+    <color rgba="0.4 0.4 0.4 1"/>
+  </material>
+  <material name="oven_silver">
+    <color rgba="0.64 0.66 0.7 1"/>
+  </material>
+  <material name="sink">
+    <color rgba="0.8 0.8 0.8 1"/>
+  </material>
+  <material name="object_mains">
+    <color rgba="0.7 0.7 0.7 1"/>
+  </material>
+  <material name="almost_white">
+    <color rgba="0.9 0.9 0.8 1"/>
+  </material>
+  <material name="black">
+    <color rgba="0.2 0.2 0.2 1"/>
+  </material>
   <link name="room_link">    
   </link>
   <!--- FIXME THIS should NOT be here -->
@@ -17,6 +38,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="sink_area_footprint_joint" type="fixed">
@@ -36,6 +58,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Sink.dae"/>
       </geometry>
+      <material name="sink"/>
     </visual>
   </link>
   <joint name="sink_area_sink_joint" type="fixed">
@@ -50,6 +73,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="sink_area_right_panel_joint" type="fixed">
@@ -64,6 +88,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_trash_drawer_handle">
@@ -73,6 +98,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="sink_area_trash_drawer_main_joint" type="prismatic">
@@ -96,6 +122,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_left_upper_drawer_handle">
@@ -105,6 +132,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="sink_area_left_upper_drawer_main_joint" type="prismatic">
@@ -128,6 +156,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_left_middle_drawer_handle">
@@ -137,6 +166,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="sink_area_left_middle_drawer_main_joint" type="prismatic">
@@ -160,6 +190,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_left_bottom_drawer_handle">
@@ -169,6 +200,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="sink_area_left_bottom_drawer_main_joint" type="prismatic">
@@ -192,6 +224,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_dish_washer_door">
@@ -201,6 +234,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="sink_area_dish_washer_door_handle">
@@ -210,6 +244,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="sink_area_dish_washer_main_joint" type="fixed">
@@ -239,6 +274,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
   </link>
   <joint name="oven_area_footprint_joint" type="fixed">
@@ -258,6 +294,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="oven_area_oven_door">
@@ -267,6 +304,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.dae"/>
       </geometry>
+      <material name="oven_silver"/>
     </visual>
   </link>
   <link name="oven_area_oven_door_handle">
@@ -276,6 +314,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <link name="oven_area_oven_panel">
@@ -285,6 +324,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.dae"/>
       </geometry>
+      <material name="oven_silver"/>
     </visual>
   </link>
   <joint name="oven_area_oven_main_joint" type="fixed">
@@ -318,6 +358,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="oven_area_oven_knob_stove_1_joint" type="revolute">
@@ -334,6 +375,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="oven_area_oven_knob_stove_2_joint" type="revolute">
@@ -350,6 +392,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="oven_area_oven_knob_stove_3_joint" type="revolute">
@@ -366,6 +409,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="oven_area_oven_knob_stove_4_joint" type="revolute">
@@ -382,6 +426,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="oven_area_oven_knob_oven_joint" type="revolute">
@@ -398,6 +443,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="oven_area_area_middle_upper_drawer_handle">
@@ -407,6 +453,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="oven_area_area_middle_upper_drawer_main_joint" type="prismatic">
@@ -430,6 +477,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="oven_area_area_middle_lower_drawer_handle">
@@ -439,6 +487,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="oven_area_area_middle_lower_drawer_main_joint" type="prismatic">
@@ -462,6 +511,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="oven_area_area_left_drawer_handle">
@@ -471,6 +521,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="oven_area_area_left_drawer_main_joint" type="prismatic">
@@ -494,6 +545,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="oven_area_area_right_drawer_handle">
@@ -503,6 +555,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="oven_area_area_right_drawer_main_joint" type="prismatic">
@@ -529,6 +582,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="kitchen_island_footprint_joint" type="fixed">
@@ -548,6 +602,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Stove.dae"/>
       </geometry>
+      <material name="black"/>
     </visual>
   </link>
   <joint name="kitchen_island_stove_joint" type="fixed">
@@ -562,6 +617,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="kitchen_island_left_panel_joint" type="fixed">
@@ -576,6 +632,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_left_upper_drawer_handle">
@@ -585,6 +642,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_left_upper_drawer_main_joint" type="prismatic">
@@ -608,6 +666,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_left_lower_drawer_handle">
@@ -617,6 +676,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_left_lower_drawer_main_joint" type="prismatic">
@@ -640,6 +700,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="kitchen_island_middle_panel_joint" type="fixed">
@@ -654,6 +715,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_middle_upper_drawer_handle">
@@ -663,6 +725,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_middle_upper_drawer_main_joint" type="prismatic">
@@ -686,6 +749,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_middle_lower_drawer_handle">
@@ -695,6 +759,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_middle_lower_drawer_main_joint" type="prismatic">
@@ -718,6 +783,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <joint name="kitchen_island_right_panel_joint" type="fixed">
@@ -732,6 +798,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_right_upper_drawer_handle">
@@ -741,6 +808,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_right_upper_drawer_main_joint" type="prismatic">
@@ -764,6 +832,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="kitchen_island_right_lower_drawer_handle">
@@ -773,6 +842,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="kitchen_island_right_lower_drawer_main_joint" type="prismatic">
@@ -799,6 +869,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
   </link>
   <joint name="fridge_area_footprint_joint" type="fixed">
@@ -818,6 +889,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="fridge_area_lower_drawer_handle">
@@ -827,6 +899,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="fridge_area_lower_drawer_main_joint" type="prismatic">
@@ -850,6 +923,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="iai_fridge_door">
@@ -859,6 +933,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
   </link>
   <link name="iai_fridge_door_handle">
@@ -868,6 +943,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.dae"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
   </link>
   <joint name="iai_fridge_main_joint" type="fixed">

--- a/resources/IAI_kitchen.urdf
+++ b/resources/IAI_kitchen.urdf
@@ -19,8 +19,8 @@
   <material name="object_mains">
     <color rgba="0.7 0.7 0.7 1"/>
   </material>
-  <material name="almost_white">
-    <color rgba="0.9 0.9 0.8 1"/>
+  <material name="environment_color">
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="black">
     <color rgba="0.2 0.2 0.2 1"/>
@@ -38,7 +38,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="sink_area_footprint_joint" type="fixed">
@@ -73,7 +73,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="sink_area_right_panel_joint" type="fixed">
@@ -88,7 +88,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_trash_drawer_handle">
@@ -122,7 +122,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_left_upper_drawer_handle">
@@ -156,7 +156,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_left_middle_drawer_handle">
@@ -190,7 +190,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_left_bottom_drawer_handle">
@@ -224,7 +224,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_dish_washer_door">
@@ -234,7 +234,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="sink_area_dish_washer_door_handle">
@@ -294,7 +294,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="oven_area_oven_door">
@@ -443,7 +443,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="oven_area_area_middle_upper_drawer_handle">
@@ -477,7 +477,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="oven_area_area_middle_lower_drawer_handle">
@@ -511,7 +511,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="oven_area_area_left_drawer_handle">
@@ -545,7 +545,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="oven_area_area_right_drawer_handle">
@@ -582,7 +582,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="kitchen_island_footprint_joint" type="fixed">
@@ -617,7 +617,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="kitchen_island_left_panel_joint" type="fixed">
@@ -632,7 +632,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_left_upper_drawer_handle">
@@ -666,7 +666,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_left_lower_drawer_handle">
@@ -700,7 +700,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="kitchen_island_middle_panel_joint" type="fixed">
@@ -715,7 +715,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_middle_upper_drawer_handle">
@@ -749,7 +749,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_middle_lower_drawer_handle">
@@ -783,7 +783,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <joint name="kitchen_island_right_panel_joint" type="fixed">
@@ -798,7 +798,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_right_upper_drawer_handle">
@@ -832,7 +832,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="kitchen_island_right_lower_drawer_handle">
@@ -889,7 +889,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="fridge_area_lower_drawer_handle">
@@ -923,7 +923,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="iai_fridge_door">
@@ -933,7 +933,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
   </link>
   <link name="iai_fridge_door_handle">

--- a/resources/apartment-follow.urdf
+++ b/resources/apartment-follow.urdf
@@ -8,19 +8,19 @@
     <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="cabinet_surface">
-    <color rgba="0.3 0.3 0.3 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="cooktop_surface">
     <color rgba="0.2 0.2 0.2 1"/>
   </material>
   <material name="cabinet_handle">
-    <color rgba="0.8 0.8 0.8 1"/>
+    <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="coloksu">
     <color rgba="0.8 0.0 0.0 1"/>
   </material>
   <material name="countertop">
-    <color rgba="0.85 0.51 0.16 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="island_sides">
     <color rgba="0.3 0.3 0.3 1"/>
@@ -117,7 +117,7 @@
     <child link="oven"/>
   </joint>
   <material name="oven_gray">
-    <color rgba="0.5 0.5 0.5 1"/>
+    <color rgba="0.64 0.66 0.7 1"/>
   </material>
   <link name="oven">
     <visual>
@@ -125,7 +125,7 @@
         <!-- <box size="0.58 0.58 0.59"/> -->
         <mesh filename="package://iai_apartment/meshes/cabinet01/oven.dae"/>
       </geometry>
-      <!-- <material name="oven_gray"/> -->
+      <material name="oven_gray"/>
     </visual>
     <collision>
       <geometry>
@@ -1597,6 +1597,7 @@
       <geometry>
         <mesh filename="package://iai_apartment/meshes/countertop/IAIKitchenPartW102H60.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <geometry>
@@ -1730,6 +1731,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.3619"/>

--- a/resources/apartment-small.urdf
+++ b/resources/apartment-small.urdf
@@ -8,19 +8,19 @@
     <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="cabinet_surface">
-    <color rgba="0.3 0.3 0.3 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="cooktop_surface">
     <color rgba="0.2 0.2 0.2 1"/>
   </material>
   <material name="cabinet_handle">
-    <color rgba="0.8 0.8 0.8 1"/>
+    <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="coloksu">
     <color rgba="0.8 0.0 0.0 1"/>
   </material>
   <material name="countertop">
-    <color rgba="0.85 0.51 0.16 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="island_sides">
     <color rgba="0.3 0.3 0.3 1"/>
@@ -266,7 +266,7 @@
     <child link="oven"/>
   </joint>
   <material name="oven_gray">
-    <color rgba="0.5 0.5 0.5 1"/>
+    <color rgba="0.64 0.66 0.7 1"/>
   </material>
   <link name="oven">
     <visual>
@@ -274,7 +274,7 @@
         <!-- <box size="0.58 0.58 0.59"/> -->
         <mesh filename="package://iai_apartment/meshes/cabinet01/oven.dae"/>
       </geometry>
-      <!-- <material name="oven_gray"/> -->
+      <material name="oven_gray"/>
     </visual>
     <collision>
       <geometry>
@@ -1746,6 +1746,7 @@
       <geometry>
         <mesh filename="package://iai_apartment/meshes/countertop/IAIKitchenPartW102H60.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <geometry>
@@ -1879,6 +1880,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.3619"/>

--- a/resources/apartment.urdf
+++ b/resources/apartment.urdf
@@ -8,19 +8,19 @@
     <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="cabinet_surface">
-    <color rgba="0.3 0.3 0.3 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="cooktop_surface">
     <color rgba="0.2 0.2 0.2 1"/>
   </material>
   <material name="cabinet_handle">
-    <color rgba="0.8 0.8 0.8 1"/>
+    <color rgba="0.6 0.6 0.6 1"/>
   </material>
   <material name="coloksu">
     <color rgba="0.8 0.0 0.0 1"/>
   </material>
   <material name="countertop">
-    <color rgba="0.85 0.51 0.16 1"/>
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="island_sides">
     <color rgba="0.3 0.3 0.3 1"/>
@@ -556,7 +556,7 @@
     <child link="oven"/>
   </joint>
   <material name="oven_gray">
-    <color rgba="0.5 0.5 0.5 1"/>
+    <color rgba="0.64 0.66 0.7 1"/>
   </material>
   <link name="oven">
     <visual>
@@ -564,7 +564,7 @@
         <!-- <box size="0.58 0.58 0.59"/> -->
         <mesh filename="package://iai_apartment/meshes/cabinet01/oven.dae"/>
       </geometry>
-      <!-- <material name="oven_gray"/> -->
+      <material name="oven_gray"/>
     </visual>
     <collision>
       <geometry>
@@ -2036,6 +2036,7 @@
       <geometry>
         <mesh filename="package://iai_apartment/meshes/countertop/IAIKitchenPartW102H60.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <geometry>
@@ -2169,6 +2170,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.3619"/>

--- a/resources/kitchen.urdf
+++ b/resources/kitchen.urdf
@@ -19,8 +19,8 @@
   <material name="object_mains">
     <color rgba="0.7 0.7 0.7 1"/>
   </material>
-  <material name="almost_white">
-    <color rgba="0.9 0.9 0.8 1"/>
+  <material name="environment_color">
+    <color rgba="0.85 0.43 0.25 1"/>
   </material>
   <material name="black">
     <color rgba="0.2 0.2 0.2 1"/>
@@ -168,7 +168,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -241,7 +241,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -266,7 +266,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -323,7 +323,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -380,7 +380,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -437,7 +437,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -494,7 +494,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -514,7 +514,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
@@ -615,7 +615,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -861,7 +861,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -918,7 +918,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -976,7 +976,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1065,7 +1065,7 @@
       <geometry>
         <box size="0.025 0.295 1.325"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1523,7 +1523,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1596,7 +1596,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1621,7 +1621,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1678,7 +1678,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1735,7 +1735,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1760,7 +1760,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1817,7 +1817,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1874,7 +1874,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1899,7 +1899,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1956,7 +1956,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2051,7 +2051,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2108,7 +2108,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2128,7 +2128,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
       </geometry>
-      <material name="almost_white"/>
+      <material name="environment_color"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/resources/kitchen.urdf
+++ b/resources/kitchen.urdf
@@ -2180,18 +2180,19 @@
   <!-- LINKS -->
   <link name="table_area_main">
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+      <origin rpy="0 0 1.570796327" xyz="0 0 0.0"/>
       <mass value="1"/>
       <inertia ixx="1" ixy="0.0" ixz="0.0" iyy="1" iyz="0.0" izz="1"/>
     </inertial>
     <visual>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <origin rpy="0 0 1.570796327" xyz="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
       </geometry>
+      <material name="environment_color"/>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <origin rpy="0 0 1.570796327" xyz="0 0 0"/>
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.stl"/>
       </geometry>
@@ -2199,14 +2200,14 @@
   </link>
   <!-- JOINTS -->
   <joint name="table_area_main_joint" type="fixed">
-    <origin rpy="0 0 3.14159265359" xyz="-1.4 -1.05 0"/>
+    <origin rpy="0 0 0" xyz="-3.3 0 0"/>
     <parent link="room_link"/>
     <child link="table_area_main"/>
   </joint>
   <!-- LINKS -->
   <link name="kitchen_wall_1">
     <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
+      <origin rpy="0 0 0" xyz="1.5 0.0 0.0"/>
       <mass value="1"/>
       <inertia ixx="1" ixy="0.0" ixz="0.0" iyy="1" iyz="0.0" izz="1"/>
     </inertial>

--- a/resources/kitchen.urdf
+++ b/resources/kitchen.urdf
@@ -166,14 +166,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.dae"/>
       </geometry>
     </collision>
   </link>
@@ -214,14 +214,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Sink.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Sink.dae"/>
       </geometry>
       <material name="sink"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Sink.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Sink.dae"/>
       </geometry>
     </collision>
   </link>
@@ -239,14 +239,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -264,14 +264,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
     </collision>
   </link>
@@ -284,14 +284,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -321,14 +321,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.dae"/>
       </geometry>
     </collision>
   </link>
@@ -341,14 +341,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
     </collision>
   </link>
@@ -378,14 +378,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -398,14 +398,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
     </collision>
   </link>
@@ -435,14 +435,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -455,14 +455,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle80.dae"/>
       </geometry>
     </collision>
   </link>
@@ -492,14 +492,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.dae"/>
       </geometry>
     </collision>
   </link>
@@ -512,14 +512,14 @@
     <visual>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.dae"/>
       </geometry>
     </collision>
   </link>
@@ -532,14 +532,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -582,14 +582,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.dae"/>
       </geometry>
       <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.dae"/>
       </geometry>
     </collision>
   </link>
@@ -613,14 +613,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.dae"/>
       </geometry>
     </collision>
   </link>
@@ -633,14 +633,14 @@
     <visual>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.dae"/>
       </geometry>
       <material name="oven_silver"/>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.dae"/>
       </geometry>
     </collision>
   </link>
@@ -653,14 +653,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -673,14 +673,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.dae"/>
       </geometry>
       <material name="oven_silver"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.dae"/>
       </geometry>
     </collision>
   </link>
@@ -724,14 +724,14 @@
     <visual>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
     </collision>
   </link>
@@ -751,14 +751,14 @@
     <visual>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
     </collision>
   </link>
@@ -778,14 +778,14 @@
     <visual>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
     </collision>
   </link>
@@ -805,14 +805,14 @@
     <visual>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
     </collision>
   </link>
@@ -832,14 +832,14 @@
     <visual>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/oven/Knob.dae"/>
       </geometry>
     </collision>
   </link>
@@ -859,14 +859,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.dae"/>
       </geometry>
     </collision>
   </link>
@@ -879,14 +879,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -916,14 +916,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.dae"/>
       </geometry>
     </collision>
   </link>
@@ -936,14 +936,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -974,14 +974,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
     </collision>
   </link>
@@ -994,14 +994,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1454,13 +1454,13 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1474,14 +1474,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1521,14 +1521,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1569,14 +1569,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Stove.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Stove.dae"/>
       </geometry>
       <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Stove.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Stove.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1594,14 +1594,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1619,14 +1619,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1639,14 +1639,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1676,14 +1676,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1696,14 +1696,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1733,14 +1733,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1758,14 +1758,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1778,14 +1778,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1815,14 +1815,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1835,14 +1835,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle100.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1872,14 +1872,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1897,14 +1897,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1917,14 +1917,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1954,14 +1954,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -1974,14 +1974,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2018,14 +2018,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0.01"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.dae"/>
       </geometry>
       <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.01"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.dae"/>
         <!--mesh filename="package://iai_kitchen/meshes/collision/kitchen_fridge.stl"/-->
       </geometry>
     </collision>
@@ -2049,14 +2049,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2069,14 +2069,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/Handle60.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2106,14 +2106,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Fridge.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/Fridge.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/Fridge.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2126,14 +2126,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
       </geometry>
       <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2146,14 +2146,14 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.dae"/>
       </geometry>
       <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.dae"/>
       </geometry>
     </collision>
   </link>
@@ -2187,7 +2187,7 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.obj"/>
+        <mesh filename="package://iai_kitchen/meshes/misc/big_table_1.dae"/>
       </geometry>
     </visual>
     <collision>

--- a/resources/kitchen.urdf
+++ b/resources/kitchen.urdf
@@ -4,6 +4,27 @@
 <!-- |    EDITING THIS FILE BY HAND IS NOT RECOMMENDED                                 | -->
 <!-- =================================================================================== -->
 <robot name="iai_oven_area" xmlns:xacro="http://ros.org/wiki/xacro">
+  <material name="cabinet_handles">
+    <color rgba="0.6 0.6 0.6 1"/>
+  </material>
+  <material name="cabinet_surface">
+    <color rgba="0.4 0.4 0.4 1"/>
+  </material>
+  <material name="oven_silver">
+    <color rgba="0.64 0.66 0.7 1"/>
+  </material>
+  <material name="sink">
+    <color rgba="0.8 0.8 0.8 1"/>
+  </material>
+  <material name="object_mains">
+    <color rgba="0.7 0.7 0.7 1"/>
+  </material>
+  <material name="almost_white">
+    <color rgba="0.9 0.9 0.8 1"/>
+  </material>
+  <material name="black">
+    <color rgba="0.2 0.2 0.2 1"/>
+  </material>
   <link name="room_link">
     <inertial>
       <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
@@ -147,6 +168,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/SinkArea.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -194,6 +216,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Sink.obj"/>
       </geometry>
+      <material name="sink"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -218,6 +241,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -242,6 +266,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -261,6 +286,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -297,6 +323,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_14.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -316,6 +343,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -352,6 +380,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -371,6 +400,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -407,6 +437,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_80_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -426,6 +457,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle80.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -462,6 +494,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasher.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -481,6 +514,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/DishWasherDoor.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
@@ -500,6 +534,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -549,6 +584,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/OvenArea.obj"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -579,6 +615,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenMain.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -598,6 +635,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenDoor.obj"/>
       </geometry>
+      <material name="oven_silver"/>
     </visual>
     <collision>
       <origin rpy="1.57079632679 0 0" xyz="0 0 0"/>
@@ -617,6 +655,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -636,6 +675,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/OvenPanel.obj"/>
       </geometry>
+      <material name="oven_silver"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -686,6 +726,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
@@ -712,6 +753,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
@@ -738,6 +780,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
@@ -764,6 +807,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
@@ -790,6 +834,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/oven/Knob.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 1.57079632679 0" xyz="0 0 0"/>
@@ -816,6 +861,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_14.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -835,6 +881,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -871,6 +918,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_58.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -890,6 +938,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -927,6 +976,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/VDrawer.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -946,6 +996,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1014,6 +1065,7 @@
       <geometry>
         <box size="0.025 0.295 1.325"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1375,7 +1427,7 @@
       <geometry>
         <box size="0.01 0.01 1.235"/>
       </geometry>
-      <material name="KitchenDarkGray"/>
+      <material name="cabinet_handles"/>
   </visual>
 
     <collision>
@@ -1424,6 +1476,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle130.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1470,6 +1523,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/IslandArea.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1517,6 +1571,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Stove.obj"/>
       </geometry>
+      <material name="black"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1541,6 +1596,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1565,6 +1621,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1584,6 +1641,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1620,6 +1678,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1639,6 +1698,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1675,6 +1735,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_100.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1699,6 +1760,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1718,6 +1780,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1754,6 +1817,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_100_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1773,6 +1837,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle100.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1809,6 +1874,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Panel_60.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1833,6 +1899,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1852,6 +1919,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1888,6 +1956,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1907,6 +1976,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1950,6 +2020,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/racks/FridgeArea.obj"/>
       </geometry>
+      <material name="cabinet_surface"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0.01"/>
@@ -1980,6 +2051,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/drawers/Drawer_60_29.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -1999,6 +2071,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/Handle60.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2035,6 +2108,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/Fridge.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2054,6 +2128,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/misc/FridgeDoor.obj"/>
       </geometry>
+      <material name="almost_white"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -2073,6 +2148,7 @@
       <geometry>
         <mesh filename="package://iai_kitchen/meshes/handles/VHandle90.obj"/>
       </geometry>
+      <material name="cabinet_handles"/>
     </visual>
     <collision>
       <origin rpy="0 0 0" xyz="0 0 0"/>

--- a/resources/kitchen.urdf
+++ b/resources/kitchen.urdf
@@ -187,24 +187,6 @@
     <parent link="sink_area_footprint"/>
     <child link="sink_area"/>
   </joint>
-  <link name="sink_area_surface">
-    <inertial>
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>
-      <mass value="1"/>
-      <inertia ixx="1" ixy="0.0" ixz="0.0" iyy="1" iyz="0.0" izz="1"/>
-    </inertial>
-    <collision>
-      <origin rpy="0 0 0" xyz="0 -0.225 0"/>
-      <geometry>
-        <box size="0.575 1.6 0.02"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint name="sink_area_surface_joint" type="fixed">
-    <origin rpy="0 0 0" xyz="0.0 0. 0.43"/>
-    <parent link="sink_area"/>
-    <child link="sink_area_surface"/>
-  </joint>
   <link name="sink_area_sink">
     <inertial>
       <origin rpy="0 0 0" xyz="0.0 0.0 0.0"/>


### PR DESCRIPTION
This updates the color schemes of the kitchen and apartment URDF models to ensure a more uniform and aesthetically consistent appearance.

Also moved the table in kitchen urdf to not collide with outer walls.